### PR TITLE
Polishing python scripts into utils.py and plotter.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /_build
 
 Rplots.pdf
+__pycache__/

--- a/analysis/ctgov/process_windows.R
+++ b/analysis/ctgov/process_windows.R
@@ -91,4 +91,16 @@ process.windows.amend.model.logistic <- function(agg.windows) {
   }
   return(agg.windows)
 }
+
+windows.hlact.write <- function(dirpath, agg.windows) {
+  fs::dir_create(dirpath)
+  for (name in agg.windows %>% names) {
+    #prefix_file <- gsub('-', '', name %>% substrRight(11))
+    prefix_file <- gsub('-', '', name %>% str_sub(start = -11))
+    file_name <- paste(prefix_file, 'hlact_studies.parquet', sep='_')
+    path2 <- file.path(dirpath, file_name)
+    agg.windows[[name]]$hlact.studies %>% write_parquet(path2)
+  }
+}
+
 # }}}

--- a/analysis/driver-rule-effective-date.R
+++ b/analysis/driver-rule-effective-date.R
@@ -31,6 +31,9 @@ process.compare.rule_effective.agg.window <- function() {
 }
 
 agg.window.compare.rule_effective <- process.compare.rule_effective.agg.window()
+
+windows.hlact.write('brick/rule-effective-date_processed', agg.window.compare.rule_effective)
+
 plot.windows.stacked.chart(agg.window.compare.rule_effective, with_names = TRUE)
 plot.windows.stacked.chart(agg.window.compare.rule_effective, with_names = TRUE, with_facet = NULL)
 

--- a/analysis/driver-sliding.R
+++ b/analysis/driver-sliding.R
@@ -28,6 +28,9 @@ windows <- window.params.filter.by.prefix(params, prefix)
 agg.windows <- process.windows.init(windows) |>
   process.windows.amend.results_reported()
 
+windows.hlact.write(glue('brick/{prefix}_processed'),
+                    agg.windows)
+
 plot.windows.pct.scatterline(agg.windows)
 
 if( FALSE ) {

--- a/analysis/plotter.py
+++ b/analysis/plotter.py
@@ -110,6 +110,7 @@ def _lollipop_plotter(df_prepost, within=36):
     size_dot = 9
     height, width = 450, 500
     p = bokeh.plotting.figure(
+        output_backend='svg',
         y_range=bokeh.models.FactorRange(*tuples[::-1]), 
         height=height, width=width, title=f"Results reported within {within} months",
         x_axis_label=f'% reporting within {within} months', x_range=(0,1)
@@ -191,6 +192,7 @@ def plot_boxplot_yearly():
     
     
     p = bokeh.plotting.figure(
+        output_backend='svg',
         height=400, width=600, y_range=(0, 52),
         x_axis_label='Start year', y_axis_label='months to report',
         title='*Of those reported* within 36 months, quantiles of months to report',
@@ -242,6 +244,7 @@ def plot_boxplot_yearly():
     p_report = d_p_report.values()
     
     p = bokeh.plotting.figure(
+        output_backend='svg',
         height=300, width=500, y_range=(-0.05, 1),
         x_axis_label='Cutoff year', y_axis_label='months to report',
         title='% Reporting Results within 36 months',

--- a/analysis/plotter.py
+++ b/analysis/plotter.py
@@ -1,0 +1,401 @@
+import numpy as np
+import pandas as pd
+import bokeh.plotting
+from bokeh.models import NumeralTickFormatter
+bokeh.io.output_notebook()
+import iqplot
+import warnings
+warnings.filterwarnings('ignore')
+import utils
+from scipy.stats import permutation_test
+from tqdm import tqdm
+    
+# TABLES OF RATES OF REPORTING OVERALL, SUBGROUPS
+# TABLES OF COMPOSITION OF SUBGROUPS
+
+def table_rates_overall(df_overall, df_pre, df_post):
+    _ = []
+    for df_, i in zip([df_overall, df_pre, df_post], ['overall', 'pre', 'post']):
+        N = len(df_)
+        n_within_12 = len(df_.loc[df_['report_within_12']])
+        n_within_36 = len(df_.loc[df_['report_within_36']])
+        p_within_12 = np.round(n_within_12 / N * 100, 1)
+        p_within_36 = np.round(n_within_36 / N * 100, 1)
+        print(i, 'N = ', N, 'trials')
+        print('% report within 12 months:', p_within_12)
+        print('% report within 36 months:', p_within_36, end='\n\n')
+
+        # Add to table to output csv
+        _.append(pd.DataFrame({'name':[f'N_trials_{i}'], 'value':[N]}))
+        _.append(pd.DataFrame({'name':[f'n_within_12_{i}'], 'value':[n_within_12]}))
+        _.append(pd.DataFrame({'name':[f'n_within_36_{i}'], 'value':[n_within_36]}))
+        _.append(pd.DataFrame({'name':[f'p_within_12_{i}'], 'value':[p_within_12]}))
+        _.append(pd.DataFrame({'name':[f'p_within_36_{i}'], 'value':[p_within_36]}))
+        
+    df_table = pd.concat(_)
+    return df_table
+
+
+def table_rates_subgroup(df_prepost_12, df_prepost_36):
+    _ = []
+    for df_, i in zip([df_prepost_12, df_prepost_36], ['12mo', '36mo']):
+        df_mod = df_.copy()
+        df_mod['rate_pre'] = np.round(df_mod['rate_pre']*100,1)
+        df_mod['rate_post'] = np.round(df_mod['rate_post']*100,1)
+        df_mod['diff_rate'] = np.round(df_mod['diff_rate']*100,1)
+        
+        df_mod = df_mod.rename(columns={
+            'rate_pre': f'rate_window1_{i} (%)', 
+            'rate_post': f'rate_window2_{i} (%)', 
+            'diff_rate': f'diff_rate_{i} (%)', 
+            })[['group', 'subgroup', f'rate_window1_{i} (%)', f'rate_window2_{i} (%)', f'diff_rate_{i} (%)']]
+        _.append(df_mod)
+    
+    df_table_rates_subgroups = _[0].merge(_[1], how='left', on=['group', 'subgroup'])
+    
+    return df_table_rates_subgroups
+
+
+def table_composition_subgroup(df_prepost_12):
+    df_ = df_prepost_12[['group', 'subgroup', 'prop_pre', 'prop_post', 'prop_overall']]
+    df_['diff_prop_prepost'] = df_['prop_post'] - df_['prop_pre']
+    df_['diff_prop_prepost'] = np.round(df_['diff_prop_prepost']*100, 1)
+    df_['prop_pre'] = np.round(df_['prop_pre']*100, 1)
+    df_['prop_post'] = np.round(df_['prop_post']*100, 1)
+    df_['prop_overall'] = np.round(df_['prop_overall']*100, 1)
+    
+    
+    return df_
+
+
+
+# LOLLIPOP PLOTTER
+def _lollipop_plotter(df_prepost, within=36):
+    
+    # # Create [(group, subgroup)...] for bokeh y-axis
+    # tuples = []
+    # for group, col_group in zip(groups, groups_col):
+    #     subgroup = df_pre[col_group].dropna().unique()
+    #     for x in subgroup:
+    #         tuples.append((group, x))
+    # copied and pasted from above, rearranged
+
+    tuples = [
+         ('funding', 'Industry'),
+         ('funding', 'NIH'),
+         ('funding', 'Other'),
+         ('phase', 'Phase 1/2 & 2'),
+         ('phase', 'Phase 2/3 & 3'),
+         ('phase', 'Phase 4'),
+         # ('phase', 'Not applicable'),
+         ('intervention', 'Biological'),
+         ('intervention', 'Drug'),
+         ('intervention', 'Device'),
+         ('intervention', 'Other'),
+         ('purpose', 'Treatment'),
+         ('purpose', 'Prevention'),
+         ('purpose', 'Other'),
+         ('status', 'Completed'),
+         ('status', 'Terminated')
+    ]
+    
+    df_prepost['group_plot'] = df_prepost.apply(lambda x: (x.group, x.subgroup), axis=1)
+
+    df_prepost['multi_line_xs'] = df_prepost.apply(lambda x: (x.rate_pre, x.rate_post), axis=1)
+    df_prepost['multi_line_ys'] = df_prepost.apply(lambda x: (x.group_plot, x.group_plot), axis=1)
+
+    color_pre = "#899DE6"
+    color_post = "darkblue"
+    size_dot = 9
+    height, width = 450, 500
+    p = bokeh.plotting.figure(
+        y_range=bokeh.models.FactorRange(*tuples[::-1]), 
+        height=height, width=width, title=f"Results reported within {within} months",
+        x_axis_label=f'% reporting within {within} months', x_range=(0,1)
+        #toolbar_location=None, tools=""
+    )
+    p.multi_line(xs='multi_line_xs', ys='multi_line_ys', 
+                 source=df_prepost, color='#ababab', line_width=1.3, line_dash='dotted')
+    p.circle(y='group_plot', x='rate_pre', source=df_prepost, color=color_pre, size=size_dot)
+    p.circle(y='group_plot', x='rate_post', source=df_prepost, color=color_post, size=size_dot)
+    
+    p.x_range.start = 0
+    p.y_range.range_padding = 0.1
+    p.yaxis.major_label_orientation = 0
+    p.ygrid.grid_line_color = None
+    
+    p.xaxis[0].formatter = NumeralTickFormatter(format="0%")
+    p.xaxis.ticker = np.arange(-0.1,1.1, 0.1)
+    
+    return p
+
+
+def plot_lollipop(df_prepost_12, df_prepost_36):      
+    
+    p_12 = _lollipop_plotter(df_prepost_12, within=12)
+    p_36 = _lollipop_plotter(df_prepost_36, within=36)
+
+    return p_12, p_36
+
+
+# BOX PLOTS BY YEAR
+def plot_boxplot_yearly():
+    df_12 = pd.read_parquet("../brick/yearly_obs36_processed/1_20120101_hlact_studies.parquet")
+    df_13 = pd.read_parquet("../brick/yearly_obs36_processed/2_20130101_hlact_studies.parquet")
+    df_14 = pd.read_parquet("../brick/yearly_obs36_processed/3_20140101_hlact_studies.parquet")
+    df_15 = pd.read_parquet("../brick/yearly_obs36_processed/4_20150101_hlact_studies.parquet")
+    df_16 = pd.read_parquet("../brick/yearly_obs36_processed/5_20160101_hlact_studies.parquet")
+    df_17 = pd.read_parquet("../brick/yearly_obs36_processed/6_20170101_hlact_studies.parquet")
+    df_18 = pd.read_parquet("../brick/yearly_obs36_processed/7_20180101_hlact_studies.parquet")
+    df_19 = pd.read_parquet("../brick/yearly_obs36_processed/8_20190101_hlact_studies.parquet")
+    df_20 = pd.read_parquet("../brick/yearly_obs36_processed/9_20200101_hlact_studies.parquet")
+    df_21 = pd.read_parquet("../brick/yearly_obs36_processed/10_20210101_hlact_studies.parquet")
+    df_22 = pd.read_parquet("../brick/yearly_obs36_processed/11_20220101_hlact_studies.parquet")
+    df_23 = pd.read_parquet("../brick/yearly_obs36_processed/12_20230101_hlact_studies.parquet")
+    df_24 = pd.read_parquet("../brick/yearly_obs36_processed/13_20240101_hlact_studies.parquet")
+
+
+    all_dfs = [df_12, df_13, df_14, df_15, df_16, 
+               df_17, df_18, df_19, df_20, df_21, df_22, df_23, df_24]
+    all_years = [ 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024]
+    
+    for df, year in zip(all_dfs, all_years):
+        df['year'] = int(year)
+        
+    df = pd.concat(all_dfs)    
+    
+    df = utils.process_months_to_report(df)
+    
+    
+    col = 'rf_months_to_report'
+    # col = 'schema1.months_to_report_results'
+    d_means = df.groupby('year')[col].mean().to_dict()
+    d_medians = df.groupby('year')[col].median().to_dict()
+    d_25 = df.groupby('year')[col].quantile(.25).to_dict()
+    d_75 = df.groupby('year')[col].quantile(.75).to_dict()
+    d_10 = df.groupby('year')[col].quantile(.10).to_dict()
+    d_90 = df.groupby('year')[col].quantile(.90).to_dict()
+    
+    years = list(d_means.keys())
+    means = list(d_means.values())
+    medians = list(d_medians.values())
+    q25s = list(d_25.values())
+    q75s = list(d_75.values())
+    q10s = list(d_10.values())
+    q90s = list(d_90.values())
+
+    
+    df['start_year'] = df['year'] - 3
+    start_years = [year - 3 for year in years]
+    
+    
+    p = bokeh.plotting.figure(
+        height=400, width=600, y_range=(0, 52),
+        x_axis_label='Start year', y_axis_label='months to report',
+        title='*Of those reported* within 36 months, quantiles of months to report',
+    )
+    
+    color_means, color_medians = 'indianred', '#232323'
+    color_25 = '#cdcdcd'
+    
+    # p.circle(x=years, y=means, legend_label='mean', color=color_means)
+    # p.line(x=years, y=means, legend_label='mean', color=color_means)
+    
+    p.multi_line(xs=[(x, x) for x in start_years], 
+                 ys=[(q25, q75) for q25, q75 in zip(q10s, q90s)],
+                 legend_label='10th & 90th percentile', 
+                 color = color_25, width=1.5, alpha=1.0, line_cap='square')
+    
+    p.multi_line(xs=[(x, x) for x in start_years], 
+                 ys=[(q25, q75) for q25, q75 in zip(q25s, q75s)],
+                 legend_label='25 & 75th percentile', 
+                 color = color_25, width=15, alpha=1.0)
+    
+    
+    intervention_pt = 2017 + 4/12 # April  (this draws the vertical line)
+    p.line((intervention_pt, intervention_pt), (-5, 90), color='maroon', alpha=0.3, width=2, 
+           legend_label='Final Rule in effect April 2017 '
+          )
+    
+    p.circle(x=start_years, y=medians, 
+             legend_label='median', 
+             color=color_medians, size=7)
+    p.line(x=start_years, y=medians, 
+           legend_label='median', 
+           color=color_medians, line_width=1, line_dash='dotted')
+    
+    p.xaxis.ticker = [2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 
+                      2018, 2019, 2020, 2021, 2022, 2023]
+    
+    p.yaxis.ticker = [0, 12, 24, 36, 48, 60, 72, 84, 96]
+    # p.yaxis.ticker = np.arange(0, 100)
+    
+    p.xgrid.grid_line_color = None
+    p_boxplot = p
+
+
+    # Create barchart of volume of those reporting
+    d_p_report = df.groupby('year')['rf_months_to_report'].apply(
+        lambda x: 1- x.isnull().sum()/len(x)).to_dict()
+    years = d_p_report.keys()
+    p_report = d_p_report.values()
+    
+    p = bokeh.plotting.figure(
+        height=300, width=500, y_range=(-0.05, 1),
+        x_axis_label='Cutoff year', y_axis_label='months to report',
+        title='% Reporting Results within 36 months',
+    )
+    color_means, color_medians = 'indianred', 'darkblue'
+    color_25 = '#a0a0a0'
+    
+    p.multi_line(xs=[(x, x) for x in years], 
+                 ys=[(0, p) for p in zip(p_report)],
+                 legend_label='% reported results within 36 months', 
+                 color = color_25, width=15, alpha=0.5)
+    
+    p.xaxis.ticker = [2011, 2012, 2013, 2014, 2015, 2016, 2017, 
+                      2018, 2019, 2020, 2021, 2022, 2023, 2024]
+    
+    p.yaxis.ticker = [0, 0.2, 0.4, 0.6, 0.8, 1.0]
+    
+    p_barchart = p
+
+    return p_boxplot, p_barchart
+
+
+
+# PERMUTATION TEST RESULTS
+def permutation_test(df_pre, df_post):
+    q_pre = df_pre['rf_months_to_report'].values
+    q_post = df_post['rf_months_to_report'].values
+    
+    # Pre: 
+    n_pre_12 = len(df_pre.loc[df_pre['rf_months_to_report'].apply(lambda x: x<=12+1/30.5)])
+    n_pre_36 = len(df_pre.loc[df_pre['rf_months_to_report'].apply(lambda x: x<=36+1/30.5)])
+    N_pre = len(q_pre)
+    p_pre_12 = n_pre_12/N_pre
+    p_pre_36 = n_pre_36/N_pre
+    
+    # Post: 
+    n_post_12 = len(df_post.loc[df_post['rf_months_to_report'].apply(lambda x: x<=12+1/30.5)])
+    n_post_36 = len(df_post.loc[df_post['rf_months_to_report'].apply(lambda x: x<=36+1/30.5)])
+    N_post = len(q_post)
+    p_post_12 = n_post_12/N_post
+    p_post_36 = n_post_36/N_post
+    
+    # print(n_pre_12, n_pre_36, n_post_12, n_post_36)
+    
+    # print(N_pre, N_post)
+    # print(p_pre_12, p_post_12, '\n',
+    #       p_pre_36, p_post_36)
+    
+    def create_array(n, N):
+        return np.hstack([np.ones(n), np.zeros(N-n)])
+    
+    def test_statistic(a, b):
+        return np.mean(b) - np.mean(a)
+    
+    # Permutation Replicate
+    # This assumes two samples are identically distributed
+    def draw_perm_sample(arr_pre, arr_post):
+        concat_data = np.concatenate((arr_pre, arr_post))
+        np.random.shuffle(concat_data)
+        return concat_data[:len(arr_pre)], concat_data[len(arr_pre):]
+    
+    def get_p_value(n_pre, N_pre, n_post, N_post, N_reps = 10_000):
+        arr_pre  = create_array(n_pre, N_pre) # pre
+        arr_post = create_array(n_post, N_post) # post
+        
+        out = np.empty(N_reps)
+        for i in tqdm(range(N_reps)):
+            sim_pre, sim_post = draw_perm_sample(arr_pre, arr_post)
+            p_pre, p_post = sum(sim_pre)/len(sim_pre), sum(sim_post)/len(sim_post)
+            sim_diff = p_post - p_pre
+            out[i] = sim_diff
+    
+        diff_orig = (n_post/N_post) - (n_pre/N_pre)
+        p_value = np.sum(out >= diff_orig) / len(out)
+        print('p-value: ', p_value)
+        return diff_orig, p_value
+    
+
+    d12, p12 = get_p_value(n_pre_12, N_pre, n_post_12, N_post, N_reps=50_000)
+    d36, p36 = get_p_value(n_pre_36, N_pre, n_post_36, N_post, N_reps=50_000)
+    results = pd.DataFrame({
+        'name':['diff_orig_12mo', 'pvalue_12mo', 'diff_orig_36mo', 'pvalue_36mo'],
+        'value':[d12, p12, d36, p36]
+    })
+    return results
+    
+
+# RUN MAIN
+if __name__ == '__main__':
+    # Get dataframes
+    path_pre_processed = "../brick/rule-effective-date_processed/datebefore_hlact_studies.parquet"
+    path_post_processed = "../brick/rule-effective-date_processed/dateafter_hlact_studies.parquet"
+    df_pre, df_post, df_overall, df_prepost_12, df_prepost_36 = utils.get_dataframes(
+        path_pre_processed, 
+        path_post_processed
+    )
+
+    
+    # Create and save 
+    # - table_rates_overall.csv,
+    # - table_rates_subgroup.csv, 
+    # - table_composition_subgroup.csv
+    print("\n Creating and saving in ../figtab/")
+    print("- table_rates_overall.csv")
+    print("- table_rates_subgroup.csv")
+    print("- table_composition_subgroup.csv \n")
+    
+    table_rates_overall_save = table_rates_overall(df_overall, df_pre, df_post)
+    table_rates_overall_save.to_csv("../figtab/table_rates_overall.csv", index=False)
+
+    table_rates_subgroup_save = table_rates_subgroup(df_prepost_12, df_prepost_36)
+    table_rates_subgroup_save.to_csv("../figtab/table_rates_subgroup.csv", index=False) 
+
+    # only needs one of them df_prepost_12, redundant columns in both 12 and 36
+    table_composition_subgroup_save = table_composition_subgroup(df_prepost_12) 
+    table_composition_subgroup_save.to_csv("../figtab/table_composition_subgroup.csv", index=False) 
+
+
+    
+    # Create and save 
+    # - p_lollipop_12.png : shows subgroups pre/post rr12mo on lollipop chart
+    # - p_lollipop_36.png : shows subgroups pre/post rr36mo on lollipop chart
+    # - p_boxplot_yearly.png  : shows boxplots of time to report of those who report within 36mo
+    # - p_barchart_yearly.png : shows proportion of those who report within 36mo
+    print("\n Creating and saving in ../figtab/ ")
+    print("- p_lollipop_12.svg and _36.svg")
+    print("- p_boxplot_yearly.svg and p_barchart_yearly.svg \n")
+    
+    p_lollipop_12, p_lollipop_36 = plot_lollipop(df_prepost_12, df_prepost_36)
+    bokeh.io.show(bokeh.layouts.row(p_lollipop_12, p_lollipop_36))
+    bokeh.io.export_svg(p_lollipop_12, filename='p_lollipop_12.svg')
+    bokeh.io.export_svg(p_lollipop_36, filename='p_lollipop_36.svg')
+
+    p_boxplot_yearly, p_barchart_yearly = plot_boxplot_yearly()
+    bokeh.io.show(bokeh.layouts.column(p_boxplot_yearly, p_barchart_yearly))
+    bokeh.io.export_svg(p_boxplot_yearly, filename='p_boxplot_yearly.svg')
+    bokeh.io.export_svg(p_barchart_yearly, filename='p_barchart_yearly.svg')
+
+
+    
+    # Create and save 
+    # - permutation_results.csv
+    print("\n Creating and saving ../figtab/permutation_results.csv...")
+    
+    permutation_results = permutation_test(df_pre, df_post)
+    permutation_results.to_csv("../figtab/permutation_results.csv", index=False) 
+
+    pass
+
+
+
+
+
+
+
+
+
+

--- a/analysis/plotter.py
+++ b/analysis/plotter.py
@@ -9,7 +9,8 @@ warnings.filterwarnings('ignore')
 import utils
 from scipy.stats import permutation_test
 from tqdm import tqdm
-    
+from pathlib import Path
+
 # TABLES OF RATES OF REPORTING OVERALL, SUBGROUPS
 # TABLES OF COMPOSITION OF SUBGROUPS
 
@@ -140,19 +141,19 @@ def plot_lollipop(df_prepost_12, df_prepost_36):
 
 # BOX PLOTS BY YEAR
 def plot_boxplot_yearly():
-    df_12 = pd.read_parquet("../brick/yearly_obs36_processed/1_20120101_hlact_studies.parquet")
-    df_13 = pd.read_parquet("../brick/yearly_obs36_processed/2_20130101_hlact_studies.parquet")
-    df_14 = pd.read_parquet("../brick/yearly_obs36_processed/3_20140101_hlact_studies.parquet")
-    df_15 = pd.read_parquet("../brick/yearly_obs36_processed/4_20150101_hlact_studies.parquet")
-    df_16 = pd.read_parquet("../brick/yearly_obs36_processed/5_20160101_hlact_studies.parquet")
-    df_17 = pd.read_parquet("../brick/yearly_obs36_processed/6_20170101_hlact_studies.parquet")
-    df_18 = pd.read_parquet("../brick/yearly_obs36_processed/7_20180101_hlact_studies.parquet")
-    df_19 = pd.read_parquet("../brick/yearly_obs36_processed/8_20190101_hlact_studies.parquet")
-    df_20 = pd.read_parquet("../brick/yearly_obs36_processed/9_20200101_hlact_studies.parquet")
-    df_21 = pd.read_parquet("../brick/yearly_obs36_processed/10_20210101_hlact_studies.parquet")
-    df_22 = pd.read_parquet("../brick/yearly_obs36_processed/11_20220101_hlact_studies.parquet")
-    df_23 = pd.read_parquet("../brick/yearly_obs36_processed/12_20230101_hlact_studies.parquet")
-    df_24 = pd.read_parquet("../brick/yearly_obs36_processed/13_20240101_hlact_studies.parquet")
+    df_12 = pd.read_parquet("brick/yearly_obs36_processed/1_20120101_hlact_studies.parquet")
+    df_13 = pd.read_parquet("brick/yearly_obs36_processed/2_20130101_hlact_studies.parquet")
+    df_14 = pd.read_parquet("brick/yearly_obs36_processed/3_20140101_hlact_studies.parquet")
+    df_15 = pd.read_parquet("brick/yearly_obs36_processed/4_20150101_hlact_studies.parquet")
+    df_16 = pd.read_parquet("brick/yearly_obs36_processed/5_20160101_hlact_studies.parquet")
+    df_17 = pd.read_parquet("brick/yearly_obs36_processed/6_20170101_hlact_studies.parquet")
+    df_18 = pd.read_parquet("brick/yearly_obs36_processed/7_20180101_hlact_studies.parquet")
+    df_19 = pd.read_parquet("brick/yearly_obs36_processed/8_20190101_hlact_studies.parquet")
+    df_20 = pd.read_parquet("brick/yearly_obs36_processed/9_20200101_hlact_studies.parquet")
+    df_21 = pd.read_parquet("brick/yearly_obs36_processed/10_20210101_hlact_studies.parquet")
+    df_22 = pd.read_parquet("brick/yearly_obs36_processed/11_20220101_hlact_studies.parquet")
+    df_23 = pd.read_parquet("brick/yearly_obs36_processed/12_20230101_hlact_studies.parquet")
+    df_24 = pd.read_parquet("brick/yearly_obs36_processed/13_20240101_hlact_studies.parquet")
 
 
     all_dfs = [df_12, df_13, df_14, df_15, df_16, 
@@ -330,9 +331,11 @@ def permutation_test(df_pre, df_post):
 
 # RUN MAIN
 if __name__ == '__main__':
+    output_dir = Path('figtab/plotter_py')
+    output_dir.mkdir(parents=True, exist_ok=True)
     # Get dataframes
-    path_pre_processed = "../brick/rule-effective-date_processed/datebefore_hlact_studies.parquet"
-    path_post_processed = "../brick/rule-effective-date_processed/dateafter_hlact_studies.parquet"
+    path_pre_processed = "brick/rule-effective-date_processed/datebefore_hlact_studies.parquet"
+    path_post_processed = "brick/rule-effective-date_processed/dateafter_hlact_studies.parquet"
     df_pre, df_post, df_overall, df_prepost_12, df_prepost_36 = utils.get_dataframes(
         path_pre_processed, 
         path_post_processed
@@ -343,20 +346,20 @@ if __name__ == '__main__':
     # - table_rates_overall.csv,
     # - table_rates_subgroup.csv, 
     # - table_composition_subgroup.csv
-    print("\n Creating and saving in ../figtab/")
+    print(f"\n Creating and saving in {output_dir}")
     print("- table_rates_overall.csv")
     print("- table_rates_subgroup.csv")
     print("- table_composition_subgroup.csv \n")
     
     table_rates_overall_save = table_rates_overall(df_overall, df_pre, df_post)
-    table_rates_overall_save.to_csv("../figtab/table_rates_overall.csv", index=False)
+    table_rates_overall_save.to_csv(output_dir / "table_rates_overall.csv", index=False)
 
     table_rates_subgroup_save = table_rates_subgroup(df_prepost_12, df_prepost_36)
-    table_rates_subgroup_save.to_csv("../figtab/table_rates_subgroup.csv", index=False) 
+    table_rates_subgroup_save.to_csv(output_dir / "table_rates_subgroup.csv", index=False) 
 
     # only needs one of them df_prepost_12, redundant columns in both 12 and 36
     table_composition_subgroup_save = table_composition_subgroup(df_prepost_12) 
-    table_composition_subgroup_save.to_csv("../figtab/table_composition_subgroup.csv", index=False) 
+    table_composition_subgroup_save.to_csv(output_dir / "table_composition_subgroup.csv", index=False) 
 
 
     
@@ -365,28 +368,29 @@ if __name__ == '__main__':
     # - p_lollipop_36.png : shows subgroups pre/post rr36mo on lollipop chart
     # - p_boxplot_yearly.png  : shows boxplots of time to report of those who report within 36mo
     # - p_barchart_yearly.png : shows proportion of those who report within 36mo
-    print("\n Creating and saving in ../figtab/ ")
+    print(f"\n Creating and saving in {output_dir}")
     print("- p_lollipop_12.svg and _36.svg")
     print("- p_boxplot_yearly.svg and p_barchart_yearly.svg \n")
     
     p_lollipop_12, p_lollipop_36 = plot_lollipop(df_prepost_12, df_prepost_36)
     bokeh.io.show(bokeh.layouts.row(p_lollipop_12, p_lollipop_36))
-    bokeh.io.export_svg(p_lollipop_12, filename='p_lollipop_12.svg')
-    bokeh.io.export_svg(p_lollipop_36, filename='p_lollipop_36.svg')
+    bokeh.io.export_svg(p_lollipop_12, filename=output_dir / 'p_lollipop_12.svg')
+    bokeh.io.export_svg(p_lollipop_36, filename=output_dir / 'p_lollipop_36.svg')
 
     p_boxplot_yearly, p_barchart_yearly = plot_boxplot_yearly()
     bokeh.io.show(bokeh.layouts.column(p_boxplot_yearly, p_barchart_yearly))
-    bokeh.io.export_svg(p_boxplot_yearly, filename='p_boxplot_yearly.svg')
-    bokeh.io.export_svg(p_barchart_yearly, filename='p_barchart_yearly.svg')
+    bokeh.io.export_svg(p_boxplot_yearly, filename=output_dir / 'p_boxplot_yearly.svg')
+    bokeh.io.export_svg(p_barchart_yearly, filename=output_dir / 'p_barchart_yearly.svg')
 
 
     
     # Create and save 
     # - permutation_results.csv
-    print("\n Creating and saving ../figtab/permutation_results.csv...")
+    output_permutation_path = output_dir / "permutation_results.csv"
+    print(f"\n Creating and saving {output_permutation_path}...")
     
     permutation_results = permutation_test(df_pre, df_post)
-    permutation_results.to_csv("../figtab/permutation_results.csv", index=False) 
+    permutation_results.to_csv(output_permutation_path, index=False) 
 
     pass
 

--- a/analysis/utils.py
+++ b/analysis/utils.py
@@ -1,0 +1,121 @@
+import numpy as np
+import pandas as pd
+import os
+import glob
+
+
+def process_months_to_report(df_):
+    df_['common.primary_completion_date_imputed'] = pd.to_datetime(
+        df_['common.primary_completion_date_imputed'], errors='coerce')
+    
+    df_['common.results_received_date'] = pd.to_datetime(
+        df_['common.results_received_date'], errors='coerce')
+    
+    # df['common.results_received_date'] = \
+    #     df['common.results_received_date'].dt.tz_localize('UTC')  # Localize tz-naive to UTC
+    df_['common.primary_completion_date_imputed'] = df_[
+        'common.primary_completion_date_imputed'].dt.tz_localize('UTC')  # Localize tz-naive to UTC
+
+    df_['rf_months_to_report'] = (df_['common.results_received_date'] - 
+     df_['common.primary_completion_date_imputed']).dt.days/30.44
+
+    df_['rf_months_to_report_plot'] = df_['rf_months_to_report'].fillna(65)
+    df_.loc[df_['rf_months_to_report_plot'] < 0, 'rf_months_to_report_plot'] = 0 
+
+    df_['report_within_12'] = df_['rf_months_to_report'] <= 12 + 1/30.5
+    df_['report_within_36'] = df_['rf_months_to_report'] <= 36 + 1/30.5
+    try:
+        df_['rr.primary_purpose'].replace({'Diagnostic':'Other'})
+    except: 
+        pass
+    return df_
+
+
+def get_d_rates(df, within):
+    groups = ['funding','phase', 'intervention','purpose', 'status'] 
+    groups_col = [ 
+        'rr.funding', 
+        'common.phase.norm', 
+        'rr.intervention_type', 
+        'rr.primary_purpose',
+        'rr.overall_status'
+    ]
+
+    d_group_col = dict(zip(groups, groups_col))
+    d_rates, d_props = {}, {}
+    for group in groups:
+        col_group = d_group_col[group]
+        d_rates[group] = df.groupby(col_group)['rf_months_to_report'].apply(
+            lambda x: (x <= within + 1/30.5).sum()/len(x)).to_dict()
+        d_props[group] = df[col_group].value_counts(normalize=True).to_dict()
+    return d_rates, d_props
+
+
+def flatten_d(d, rate_col = 'rate'):
+    df_ = pd.DataFrame(columns={'group':[], 'subgroup':[], rate_col:[]})
+    groups = d.keys()
+    for group in groups:
+        d_group = d[group]
+        subgroups = d_group.keys()
+        rates = d_group.values()
+        row = pd.DataFrame({'group':group, 'subgroup':subgroups, rate_col:rates})
+        df_ = pd.concat([df_, row])
+    return df_
+
+    
+def get_prepost_dataframes(
+    d_rates_pre, d_rates_post, d_rates_overall,
+    d_props_pre, d_props_post, d_props_overall,
+    ):
+    df_pre = flatten_d(d_rates_pre, rate_col='rate_pre').merge(
+        flatten_d(d_props_pre, rate_col='prop_pre'))
+    df_post = flatten_d(d_rates_post, rate_col='rate_post').merge(
+        flatten_d(d_props_post, rate_col='prop_post')
+    )
+    df_overall = flatten_d(d_rates_overall, rate_col='rate_overall').merge(
+        flatten_d(d_props_overall, rate_col='prop_overall')
+    )
+    
+    df_prepost = df_pre.merge(df_post, on=['group', 'subgroup'], how='left'
+                ).merge(df_overall, on=['group', 'subgroup'], how='left')
+    
+    df_prepost['diff_rate'] = df_prepost['rate_post'] - df_prepost['rate_pre']
+    return df_prepost
+
+
+def get_dataframes(path_pre_processed, path_post_processed):
+    # path_pre = "../brick/pre-post-2017_processed/1_20200101_hlact_studies.parquet")
+    # path_post = "../brick/pre-post-2017_processed/2_20240101_hlact_studies.parquet")
+    df_pre = pd.read_parquet(path_pre_processed)
+    df_post = pd.read_parquet(path_post_processed)
+    
+    df_pre = process_months_to_report(df_pre)
+    df_post = process_months_to_report(df_post)
+    df_overall = pd.concat([df_pre, df_post])
+    #  Reduce duplicates, takes latest version number
+    df_overall = df_overall[ 
+        df_overall.groupby('schema1.nct_id_1')['schema1.version_number'
+        ].rank(method='max') == 1 
+    ]
+
+    # Gets pre and post aggregate rates within 12 and 36 months
+    groups = ['funding','phase', 'intervention','purpose'] 
+    groups_col = [ 'rr.funding', 'common.phase.norm', 'rr.intervention_type', 'rr.primary_purpose']
+    
+    d_rates_pre_12, d_props_pre_12 = get_d_rates(df_pre, within=12)
+    d_rates_post_12, d_props_post_12 = get_d_rates(df_post, within=12)
+    d_rates_overall_12, d_props_overall_12 = get_d_rates(df_overall, within=12)
+    
+    d_rates_pre_36, d_props_pre_36 = get_d_rates(df_pre, within=36)
+    d_rates_post_36, d_props_post_36 = get_d_rates(df_post, within=36)
+    d_rates_overall_36, d_props_overall_36 = get_d_rates(df_overall, within=36)
+    
+    
+    df_prepost_12 = get_prepost_dataframes(d_rates_pre_12, d_rates_post_12, d_rates_overall_12, 
+                                           d_props_pre_12, d_props_post_12, d_props_overall_12)
+    df_prepost_36 = get_prepost_dataframes(d_rates_pre_36, d_rates_post_36, d_rates_overall_36,
+                                           d_props_pre_36, d_props_post_36, d_props_overall_36)
+        
+    return df_pre, df_post, df_overall, df_prepost_12, df_prepost_36
+
+

--- a/dvc.lock
+++ b/dvc.lock
@@ -1909,3 +1909,30 @@ stages:
       hash: md5
       md5: 2d077c9ba40313578c19d1282734c7c0
       size: 1583593
+  plotter_py:
+    cmd: "python3 analysis/plotter.py\n"
+    deps:
+    - path: analysis/plotter.py
+      hash: md5
+      md5: aec5b3db0c9b2c9f88319fe5f1e6ca49
+      size: 15847
+    - path: analysis/utils.py
+      hash: md5
+      md5: eaac24364b7b89e4d11c23315a970909
+      size: 4888
+    - path: brick/rule-effective-date_processed
+      hash: md5
+      md5: a4330e3c2dc160c6b7b59a45215bf0c7.dir
+      size: 1692827
+      nfiles: 2
+    - path: brick/yearly_obs36_processed
+      hash: md5
+      md5: 103192c6b313182437881466c4b56f0a.dir
+      size: 4279189
+      nfiles: 13
+    outs:
+    - path: figtab/plotter_py
+      hash: md5
+      md5: 3f684049db09a84e24e9d5d3a06665b9.dir
+      size: 102888
+      nfiles: 8

--- a/dvc.lock
+++ b/dvc.lock
@@ -697,8 +697,8 @@ stages:
     deps:
     - path: analysis/driver-sliding.R
       hash: md5
-      md5: f09469d9cd2ad4a87e07a02842aa4cee
-      size: 1110
+      md5: 8a565a69f139ecf2195eac78dfdb796f
+      size: 1198
     - path: brick/long-observe
       hash: md5
       md5: 6c67982e1e1b1ddadb623a5c22afc911.dir
@@ -709,10 +709,15 @@ stages:
       md5: 59a86acc308c6ac883bc751ebac18b44
       size: 10815
     outs:
+    - path: brick/long-observe_processed
+      hash: md5
+      md5: 7f114558dc386ab62373d7dec0ff773d.dir
+      size: 4431208
+      nfiles: 4
     - path: figtab/long-observe
       hash: md5
-      md5: ef6ebb204049b0cd5e7d024cdd14d9fa.dir
-      size: 687048
+      md5: 8e983307945ff0c828c2179f207266b6.dir
+      size: 895362
       nfiles: 3
   build-ctgov-studies-all@rule-effective-date-before:
     cmd:
@@ -877,21 +882,21 @@ stages:
     outs:
     - path: figtab/anderson2015.new
       hash: md5
-      md5: 5b5ebfa58ab3bffe6b6a5a5c4f3f0333.dir
-      size: 179672
+      md5: cbc7daa8adf1de14e8808960d23b5af1.dir
+      size: 190075
       nfiles: 1
     - path: figtab/anderson2015.original
       hash: md5
-      md5: 499dadb4e81539542cef5d9c0c0b10b5.dir
-      size: 183379
+      md5: 3e26d4af9cf6c456f8997884d0c300c8.dir
+      size: 193670
       nfiles: 1
   analysis-driver-rule-effective-date:
     cmd: "Rscript analysis/driver-rule-effective-date.R\n"
     deps:
     - path: analysis/driver-rule-effective-date.R
       hash: md5
-      md5: 779af7ddd2e57d2dd29e205d8334c1fb
-      size: 3130
+      md5: 360b8ffff854d31391b2b40c0452734b
+      size: 3226
     - path: brick/rule-effective-date-after
       hash: md5
       md5: 5443d6aa379ea48e231086ec016b6e4e.dir
@@ -907,10 +912,15 @@ stages:
       md5: 59a86acc308c6ac883bc751ebac18b44
       size: 10815
     outs:
+    - path: brick/rule-effective-date_processed
+      hash: md5
+      md5: a4330e3c2dc160c6b7b59a45215bf0c7.dir
+      size: 1692827
+      nfiles: 2
     - path: figtab/rule-effective
       hash: md5
-      md5: 180ac882f14cb3929cc1fad29a50a4e7.dir
-      size: 2046379
+      md5: 9b4f721ed59d9e2fb4494ed1be1a3fcb.dir
+      size: 2073723
       nfiles: 10
   build-ctgov-studies-all@yearly_obs36_n-1_20120101:
     cmd:
@@ -1697,8 +1707,8 @@ stages:
     deps:
     - path: analysis/driver-sliding.R
       hash: md5
-      md5: f09469d9cd2ad4a87e07a02842aa4cee
-      size: 1110
+      md5: 8a565a69f139ecf2195eac78dfdb796f
+      size: 1198
     - path: brick/yearly_obs36
       hash: md5
       md5: e42223413aafb8cfae72b046cafe136f.dir
@@ -1709,10 +1719,15 @@ stages:
       md5: 59a86acc308c6ac883bc751ebac18b44
       size: 10815
     outs:
+    - path: brick/yearly_obs36_processed
+      hash: md5
+      md5: 103192c6b313182437881466c4b56f0a.dir
+      size: 4279189
+      nfiles: 13
     - path: figtab/yearly_obs36
       hash: md5
-      md5: ec2c46b8137f1884f1bffc649893726f.dir
-      size: 1341718
+      md5: c04d2380b575f381a748593208ba141f.dir
+      size: 1706369
       nfiles: 3
   build-ctgov-studies-all@pre-post-2017_n-1_20200101:
     cmd:

--- a/dvc.yaml
+++ b/dvc.yaml
@@ -111,6 +111,7 @@ stages:
       - analysis/driver-sliding.R
     outs:
       - figtab/long-observe
+      - brick/long-observe_processed
   analysis-driver-sliding_yearly_obs36:
     cmd: |
       Rscript analysis/driver-sliding.R params.yaml yearly_obs36
@@ -120,6 +121,7 @@ stages:
       - analysis/driver-sliding.R
     outs:
       - figtab/yearly_obs36
+      - brick/yearly_obs36_processed
   analysis-driver-anderson2015-compare-stacked:
     cmd: |
       Rscript analysis/driver-anderson2015-compare-stacked.R
@@ -141,3 +143,4 @@ stages:
       - analysis/driver-rule-effective-date.R
     outs:
       - figtab/rule-effective
+      - brick/rule-effective-date_processed

--- a/dvc.yaml
+++ b/dvc.yaml
@@ -144,3 +144,13 @@ stages:
     outs:
       - figtab/rule-effective
       - brick/rule-effective-date_processed
+  plotter_py:
+    cmd: |
+      python3 analysis/plotter.py
+    deps:
+      - analysis/plotter.py
+      - analysis/utils.py
+      - brick/rule-effective-date_processed
+      - brick/yearly_obs36_processed
+    outs:
+      - figtab/plotter_py

--- a/figtab/.gitignore
+++ b/figtab/.gitignore
@@ -5,3 +5,4 @@
 /anderson2015.new
 /rule-effective
 /yearly_obs36
+/plotter_py

--- a/figtab/table_composition_subgroup_save.csv
+++ b/figtab/table_composition_subgroup_save.csv
@@ -1,0 +1,18 @@
+group,subgroup,prop_pre,prop_post,prop_overall,diff_prop_prepost
+funding,NIH,18.6,9.2,14.7,-9.4
+funding,Industry,47.4,38.5,43.7,-8.9
+funding,Other,34.0,52.3,41.6,18.3
+phase,Phase 1/2 & 2,35.8,19.9,29.3,-15.9
+phase,Phase 2/3 & 3,18.9,10.5,15.5,-8.4
+phase,Phase 4,10.4,7.0,9.0,-3.4
+phase,N/A,34.8,62.6,46.2,27.8
+intervention,Drug,53.6,31.4,44.5,-22.2
+intervention,Device,10.4,18.8,13.9,8.3
+intervention,Biological,6.9,3.9,5.6,-3.0
+intervention,Other,29.1,46.0,36.0,16.8
+purpose,Treatment,74.2,54.7,65.9,-19.6
+purpose,Prevention,10.7,11.3,10.9,0.6
+purpose,Diagnostic,3.7,3.5,3.6,-0.2
+purpose,Other,11.4,30.6,19.5,19.2
+status,Completed,84.7,83.5,84.2,-1.2
+status,Terminated,15.3,16.5,15.8,1.2

--- a/flake.nix
+++ b/flake.nix
@@ -57,7 +57,7 @@
               parallelWithPerlEnv = pkgs.stdenv.mkDerivation {
                 name = "parallel-with-perl-env";
                 buildInputs = [ pkgs.parallel pkgs.makeWrapper ];
-                propagatedBuildInputs = [ extraPerlPackages ];
+                propagatedBuildInputs = extraPerlPackages;
                 unpackPhase = "true";
                 installPhase = ''
                   mkdir -p $out/bin

--- a/flake.nix
+++ b/flake.nix
@@ -84,11 +84,32 @@
               rEnv = pkgs.rWrapper.override {
                 packages = extraRPackages;
               };
+
+              python3PackageOverrides = pkgs.callPackage ./maint/nixpkg/python3/packages.nix { };
+              python = pkgs.python3.override { packageOverrides = python3PackageOverrides; };
+              extraPython3Packages = ps: with ps; [
+                  numpy
+                  pandas
+                  scipy
+                  pyarrow
+                  fastparquet
+                  openpyxl
+                  bokeh
+                  tqdm
+                  iqplot
+                  ipython
+                  selenium
+                ];
+              python3Env = python.withPackages extraPython3Packages ;
                 in {
             buildInputs =
-              [ parallelWithPerlEnv rEnv ]
-              ++ oldAttrs.buildInputs
-              ++ [ (pkgs.python3.withPackages (ps: with ps; [ pandas pyarrow fastparquet openpyxl ])) ]
+              [
+                parallelWithPerlEnv
+                rEnv
+                python3Env
+                pkgs.chromium
+                pkgs.chromedriver
+              ] ++ oldAttrs.buildInputs
               ;
             env = oldAttrs.env // {
               LC_ALL = "C";

--- a/maint/nixpkg/python3/packages.nix
+++ b/maint/nixpkg/python3/packages.nix
@@ -1,0 +1,31 @@
+{ lib
+, pkgs
+, fetchPypi
+ }:
+
+self: super: {
+  iqplot = super.buildPythonPackage rec {
+    pname = "iqplot";
+    version = "0.3.7";
+    pyproject = true;
+
+    src = fetchPypi {
+      inherit pname version;
+      hash = "sha256-jlY0u5+Iw0hXkNDcaVMEPnEV2xzvy968EW0QC954KeA=";
+    };
+
+    build-system = [
+      super.setuptools-scm
+    ];
+
+    propagatedBuildInputs = [
+      super.numpy
+      super.xarray
+      super.pandas
+      super.bokeh
+      super.colorcet
+    ];
+
+    nativeCheckInputs = [];
+  };
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,14 @@
 pandas>=2.2.2
 python-calamine
+numpy
+bokeh
+iqplot
+scipy
+tqdm
+
 pyarrow
 fastparquet
+openpyxl
+
+#graphviz
+#duckdb


### PR DESCRIPTION
Two files `utils.py` and `plotter.py`. Running the main function of `plotter.py` will generate the following outputs in `figtab`:

- `table_rates_overall.csv`
- `table_rates_subgroups.csv`
- `permutation_results.csv`
- `p_lollipop_12.svg`
- `p_lollipop_36.svg`
- `p_boxplot_yearly.svg`
- `p_barchart_yearly.svg`

utils.py cleans up the dataframes for plotting and analysis in Python, and plotter.py runs all the code for the tables, figures, and permutation test.
```
$ python3 plotter.py
```