### PR TITLE
Permutation test by subgroup (rebased #42)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,11 @@
 /log
 /_build
 
+# Jupyter
+.ipynb_checkpoints/
+
+# R
 Rplots.pdf
+
+# Python
 __pycache__/

--- a/analysis/plotter.py
+++ b/analysis/plotter.py
@@ -9,6 +9,7 @@ warnings.filterwarnings('ignore')
 import utils
 from scipy.stats import permutation_test
 from tqdm import tqdm
+
 from pathlib import Path
 
 # TABLES OF RATES OF REPORTING OVERALL, SUBGROUPS
@@ -156,7 +157,6 @@ def plot_boxplot_yearly():
     df_23 = pd.read_parquet("brick/yearly_obs36_processed/12_20230101_hlact_studies.parquet")
     df_24 = pd.read_parquet("brick/yearly_obs36_processed/13_20240101_hlact_studies.parquet")
 
-
     all_dfs = [df_12, df_13, df_14, df_15, df_16, 
                df_17, df_18, df_19, df_20, df_21, df_22, df_23, df_24]
     all_years = [ 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024]
@@ -268,31 +268,7 @@ def plot_boxplot_yearly():
 
 
 
-# PERMUTATION TEST RESULTS
-def permutation_test(df_pre, df_post):
-    q_pre = df_pre['rf_months_to_report'].values
-    q_post = df_post['rf_months_to_report'].values
-    
-    # Pre: 
-    n_pre_12 = len(df_pre.loc[df_pre['rf_months_to_report'].apply(lambda x: x<=12+1/30.5)])
-    n_pre_36 = len(df_pre.loc[df_pre['rf_months_to_report'].apply(lambda x: x<=36+1/30.5)])
-    N_pre = len(q_pre)
-    p_pre_12 = n_pre_12/N_pre
-    p_pre_36 = n_pre_36/N_pre
-    
-    # Post: 
-    n_post_12 = len(df_post.loc[df_post['rf_months_to_report'].apply(lambda x: x<=12+1/30.5)])
-    n_post_36 = len(df_post.loc[df_post['rf_months_to_report'].apply(lambda x: x<=36+1/30.5)])
-    N_post = len(q_post)
-    p_post_12 = n_post_12/N_post
-    p_post_36 = n_post_36/N_post
-    
-    # print(n_pre_12, n_pre_36, n_post_12, n_post_36)
-    
-    # print(N_pre, N_post)
-    # print(p_pre_12, p_post_12, '\n',
-    #       p_pre_36, p_post_36)
-    
+def permutation_test(n_pre, N_pre, n_post, N_post, N_reps=50_000):
     def create_array(n, N):
         return np.hstack([np.ones(n), np.zeros(N-n)])
     
@@ -321,16 +297,63 @@ def permutation_test(df_pre, df_post):
         p_value = np.sum(out >= diff_orig) / len(out)
         print('p-value: ', p_value)
         return diff_orig, p_value
+        
+    diff_orig, p_value = get_p_value(n_pre, N_pre, n_post, N_post, N_reps=N_reps)
+    return diff_orig, p_value
+    
+    
+# PERMUTATION TEST RESULTS
+def permutation_test_overall(df_pre, df_post, N_reps=50_000):
+    q_pre = df_pre['rf_months_to_report'].values
+    q_post = df_post['rf_months_to_report'].values
+    
+    # Pre: 
+    n_pre_12 = len(df_pre.loc[df_pre['rf_months_to_report'].apply(lambda x: x<=12+1/30.5)])
+    n_pre_36 = len(df_pre.loc[df_pre['rf_months_to_report'].apply(lambda x: x<=36+1/30.5)])
+    N_pre = len(q_pre)
+    p_pre_12 = n_pre_12/N_pre
+    p_pre_36 = n_pre_36/N_pre
+    
+    # Post: 
+    n_post_12 = len(df_post.loc[df_post['rf_months_to_report'].apply(lambda x: x<=12+1/30.5)])
+    n_post_36 = len(df_post.loc[df_post['rf_months_to_report'].apply(lambda x: x<=36+1/30.5)])
+    N_post = len(q_post)
+    p_post_12 = n_post_12/N_post
+    p_post_36 = n_post_36/N_post
+    
+    # print(n_pre_12, n_pre_36, n_post_12, n_post_36)
+    
+    # print(N_pre, N_post)
+    # print(p_pre_12, p_post_12, '\n',
+    #       p_pre_36, p_post_36)
     
 
-    d12, p12 = get_p_value(n_pre_12, N_pre, n_post_12, N_post, N_reps=50_000)
-    d36, p36 = get_p_value(n_pre_36, N_pre, n_post_36, N_post, N_reps=50_000)
+    d12, p12 = permutation_test(n_pre_12, N_pre, n_post_12, N_post, N_reps=N_reps)
+    d36, p36 = permutation_test(n_pre_36, N_pre, n_post_36, N_post, N_reps=N_reps)
     results = pd.DataFrame({
         'name':['diff_orig_12mo', 'pvalue_12mo', 'diff_orig_36mo', 'pvalue_36mo'],
         'value':[d12, p12, d36, p36]
     })
     return results
     
+
+
+def permutation_test_subgroup(row, N_reps=50_000):
+    n_pre, N_pre, n_post, N_post = row.n_pre, row.N_pre, row.n_post, row.N_post
+    diff_orig, p_value = permutation_test(n_pre, N_pre, n_post, N_post, N_reps=N_reps)
+    return p_value
+
+
+def table_pvalues_subgroup_save(df_prepost_12, df_prepost_36):
+    table = df_prepost_12[['group', 'subgroup', 'rate_pre', 'rate_post', 'p_value']].rename(
+        columns={'rate_pre':'rate_pre_12mo',
+                 'rate_post':'rate_post_12mo',
+                 'p_value':'p_value_12mo'}).merge(
+        df_prepost_36[['group', 'subgroup', 'rate_pre', 'rate_post', 'p_value']].rename(
+        columns={'rate_pre':'rate_pre_36mo',
+                 'rate_post':'rate_post_36mo',
+                 'p_value':'p_value_36mo'}))
+    return table
 
 # RUN MAIN
 if __name__ == '__main__':
@@ -349,6 +372,7 @@ if __name__ == '__main__':
     # - table_rates_overall.csv,
     # - table_rates_subgroup.csv, 
     # - table_composition_subgroup.csv
+
     print(f"\n Creating and saving in {output_dir}")
     print("- table_rates_overall.csv")
     print("- table_rates_subgroup.csv")
@@ -365,17 +389,20 @@ if __name__ == '__main__':
     table_composition_subgroup_save.to_csv(output_dir / "table_composition_subgroup.csv", index=False) 
 
 
+
     
     # Create and save 
     # - p_lollipop_12.png : shows subgroups pre/post rr12mo on lollipop chart
     # - p_lollipop_36.png : shows subgroups pre/post rr36mo on lollipop chart
     # - p_boxplot_yearly.png  : shows boxplots of time to report of those who report within 36mo
     # - p_barchart_yearly.png : shows proportion of those who report within 36mo
+
     print(f"\n Creating and saving in {output_dir}")
     print("- p_lollipop_12.svg and _36.svg")
     print("- p_boxplot_yearly.svg and p_barchart_yearly.svg \n")
     
     p_lollipop_12, p_lollipop_36 = plot_lollipop(df_prepost_12, df_prepost_36)
+
     bokeh.io.show(bokeh.layouts.row(p_lollipop_12, p_lollipop_36))
     bokeh.io.export_svg(p_lollipop_12, filename=output_dir / 'p_lollipop_12.svg')
     bokeh.io.export_svg(p_lollipop_36, filename=output_dir / 'p_lollipop_36.svg')
@@ -386,14 +413,23 @@ if __name__ == '__main__':
     bokeh.io.export_svg(p_barchart_yearly, filename=output_dir / 'p_barchart_yearly.svg')
 
 
+
     
     # Create and save 
     # - permutation_results.csv
     output_permutation_path = output_dir / "permutation_results.csv"
     print(f"\n Creating and saving {output_permutation_path}...")
     
-    permutation_results = permutation_test(df_pre, df_post)
+    N_reps = 50_000
+    permutation_results = permutation_test_overall(df_pre, df_post, N_reps=N_reps)
     permutation_results.to_csv(output_permutation_path, index=False) 
+    
+    df_prepost_12['p_value'] = df_prepost_12.apply(permutation_test_subgroup, axis=1, args=(N_reps,))
+    df_prepost_36['p_value'] = df_prepost_36.apply(permutation_test_subgroup, axis=1, args=(N_reps,))
+    
+    permutation_results_subgroup = table_pvalues_subgroup_save(df_prepost_12, df_prepost_36)
+    permutation_results_subgroup.to_csv( output_dir / "permutation_results_subgroup.csv", index=False)
+    
 
     pass
 


### PR DESCRIPTION
Rebased version of <https://github.com/insilica/clinicaltrials-compliance-study/pull/42>.

```sh
# 8019942 is the merge commit on #42
$ git diff 8019942 fd8bc39527cc823a4eafded3cdcc9bf1e6855a6d -- analysis/
```

```diff
diff --git a/analysis/plotter.py b/analysis/plotter.py
index 5e4c8a8..411dd97 100644
--- a/analysis/plotter.py
+++ b/analysis/plotter.py
@@ -428,7 +428,7 @@ if __name__ == '__main__':
     df_prepost_36['p_value'] = df_prepost_36.apply(permutation_test_subgroup, axis=1, args=(N_reps,))
     
     permutation_results_subgroup = table_pvalues_subgroup_save(df_prepost_12, df_prepost_36)
-    permutation_results_subgroup.to_csv("../figtab/permutation_results_subgroup.csv", index=False)
+    permutation_results_subgroup.to_csv( output_dir / "permutation_results_subgroup.csv", index=False)
     
 
     pass
```
